### PR TITLE
fix(package.json): Remove subdomain/domain properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,6 @@
     "hoodie-plugin-email": "~0.1.1",
     "hoodie-plugin-users": "0.1.0"
   },
-  "subdomain": "hoodie-testMoufle",
-  "domains": [
-    "admin.hoodie-testMoufle.jit.su",
-    "couch.hoodie-testMoufle.jit.su"
-  ],
   "scripts": {
     "start": "node node_modules/hoodie-server/bin/start"
   },


### PR DESCRIPTION
These properties refer to nodejitsu (I believe, I can't find any reference to them in npm docs), which is now defunct/within GoDaddy.